### PR TITLE
Fix GitHub Actions workflow to deploy from docs directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,4 +31,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: ./docs


### PR DESCRIPTION
## Summary
- Updated GitHub Actions workflow to deploy from the correct directory (./docs)
- Previous configuration was looking for ./dist which is not used in this project
- This will fix the GitHub Pages deployment action

## Test plan
- Merge PR and verify that the GitHub Actions workflow successfully deploys to GitHub Pages
